### PR TITLE
stopped SteamId#fetch_games from caching an empty hash in @games when an...

### DIFF
--- a/lib/steam/community/steam_id.rb
+++ b/lib/steam/community/steam_id.rb
@@ -327,9 +327,9 @@ class SteamId
   #
   # @see #games
   def fetch_games
+    games_data = parse "#{base_url}/games?xml=1"
     @games     = {}
     @playtimes = {}
-    games_data = parse "#{base_url}/games?xml=1"
     games_data['games']['game'].each do |game_data|
       app_id = game_data['appID'].to_i
       game = SteamGame.new app_id, game_data

--- a/test/steam/community/test_steam_id.rb
+++ b/test/steam/community/test_steam_id.rb
@@ -123,6 +123,17 @@ class TestSteamId < Test::Unit::TestCase
       end
       assert_equal 'XML data could not be parsed.', error.message
     end
+    
+    should 'not cache an empty hash when an error is encountered on steam' do
+      SteamId.any_instance.expects(:parse).raises(OpenURI::HTTPError.new('', nil))
+      steam_id = SteamId.new(76561197983311154, false)
+      
+      assert_raises OpenURI::HTTPError do
+        steam_id.games
+      end
+      
+      assert_equal(nil, steam_id.instance_variable_get("@games"))
+    end
 
     teardown do
       SteamId.clear_cache


### PR DESCRIPTION
... error is raised while parsing "#{base_url}/games?xml=1"

The Steam Community pages are throwing 503s. Made a change so that when fetch_games is called on a SteamId instance and a 503 is encountered, it does not cache an empty hash.
