### PR TITLE
Fixed class-method call in SteamId initializer

### DIFF
--- a/lib/steam/community/steam_id.rb
+++ b/lib/steam/community/steam_id.rb
@@ -205,7 +205,7 @@ class SteamId
       @steam_id64 = id
     else
       if id =~ /^STEAM_[0-1]:[0-1]:[0-9]+$/ || id =~ /\[U:[0-1]:[0-9]+\]/
-        @steam_id64 = self.steam_id_to_community_id id
+        @steam_id64 = SteamId.steam_id_to_community_id id
       else
         @custom_url = id.downcase
       end


### PR DESCRIPTION
If you call SteamId.new with a steamid (STEAM_*), the initializer fails without this fix. Looks like a regression from changing the signatures of the conversion methods from instance to class methods.
