### PR TITLE
Require all in steam-condenser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 pkg
 doc
+coverage

--- a/lib/steam-condenser.rb
+++ b/lib/steam-condenser.rb
@@ -9,9 +9,11 @@
 # point when using the gem (i.e. +require 'steam-condenser').
 #
 # @author Sebastian Staudt
+
 module SteamCondenser
 end
 
 require 'steam-condenser/logging'
 require 'steam-condenser/version'
-require 'steam-condenser/all'
+require 'steam-condenser/community/all'
+require 'steam-condenser/servers/all'

--- a/lib/steam-condenser/all.rb
+++ b/lib/steam-condenser/all.rb
@@ -1,7 +1,0 @@
-# This code is free software; you can redistribute it and/or modify it under
-# the terms of the new BSD License.
-#
-# Copyright (c) 2012, Sebastian Staudt
-
-require 'steam-condenser/community/all'
-require 'steam-condenser/servers/all'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,7 +16,7 @@ require 'shoulda-context'
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 $LOAD_PATH.unshift File.dirname(__FILE__)
 
-require 'steam-condenser/all'
+require 'steam-condenser'
 include SteamCondenser
 
 # Extends TestCase functionality


### PR DESCRIPTION
This must be included, because now showing `uninitialized constant SteamCondenser::Servers` when requiring only `steam-condenser`.
