### PR TITLE
Update incorrect TimeoutError class name

### DIFF
--- a/lib/steam-condenser/servers/sockets/source_socket.rb
+++ b/lib/steam-condenser/servers/sockets/source_socket.rb
@@ -54,7 +54,7 @@ module SteamCondenser::Servers::Sockets
           if split_packets.size < packet_count
             begin
               bytes_read = receive_packet
-            rescue SteamCondenser::TimeoutError
+            rescue SteamCondenser::Error::Timeout
             end
           end
         end while bytes_read > 0 && @buffer.long == 0xFFFFFFFE


### PR DESCRIPTION
SteamCondenser::TimeoutError was renamed to SteamCondenser::Error::Timeout
