### PR TITLE
RCONBanError was renamed to RCONBan

### DIFF
--- a/lib/steam-condenser/servers/source_server.rb
+++ b/lib/steam-condenser/servers/source_server.rb
@@ -80,7 +80,7 @@ module SteamCondenser
         @rcon_socket.send Packets::RCON::RCONAuthRequest.new @rcon_request_id, password
 
         reply = @rcon_socket.reply
-        raise RCONBanError if reply.nil?
+        raise Error::RCONBan if reply.nil?
         reply = @rcon_socket.reply
         @rcon_authenticated = reply.request_id == @rcon_request_id
       end


### PR DESCRIPTION
Use the correct error class when rcon_auth fails
