### PR TITLE
Add support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
   - jruby-19mode
   - jruby-head
   - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  * [ENHANCEMENT] Provide a simple way to get parsed JSON from Web API
  * [ENHANCEMENT] Removed old hackish master server functionality
  * [ENHANCEMENT] Removed deprecated aliases from SteamId
+ * [ENHANCEMENT] Add support for Ruby 2.2
+ * [ENHANCEMENT] Drop support for Ruby 1.9
 
 ## Version 1.3.10 / 2015-01-04
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently it is implemented in Java, PHP and Ruby.
 
 ## Requirements
 
-* Ruby 1.9.2 or newer (and compatible Ruby VMs)
+* Ruby 2.0 or newer (and compatible Ruby VMs)
 * Any operating system able to run such a VM
 
 The following gems are required:

--- a/steam-condenser.gemspec
+++ b/steam-condenser.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Steam Condenser - A Steam query library'
   s.description = 'A multi-language library for querying the Steam Community, Source, GoldSrc servers and Steam master servers'
 
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.0'
 
   s.add_dependency 'multi_json', '~> 1.6'
   s.add_dependency 'multi_xml', '~> 0.5'
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'shoulda-context', '~> 1.2'
+  s.add_development_dependency 'test-unit', '~> 3.0'
   s.add_development_dependency 'yard', '~> 0.8'
 
   s.files              = Dir.glob '**/*'


### PR DESCRIPTION
This PR adds support for Ruby MRI 2.2. It also adjusts Travis CI to always run on the latest PATCH version of the Ruby release (Ruby 2.1 instead of Ruby 2.1.0). Needed to include `test-unit` as dev dependency now as it's not shipped with Ruby 2.2 anymore.

We could also include dropping support of Ruby MRI 1.9.3, the official support has just ended (https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/).