### PR TITLE
Cache bundler on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 sudo: false
 rvm:
   - 1.9.2


### PR DESCRIPTION
Caches gems installed via bundler inbetween CI runs. Check http://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies) for details.