### PR TITLE
bugfix: Change qualityNames key to qualities to match API response

### DIFF
--- a/lib/steam-condenser/community/game_item_schema.rb
+++ b/lib/steam-condenser/community/game_item_schema.rb
@@ -118,7 +118,7 @@ module SteamCondenser::Community
 
       @qualities = []
       data[:qualities].keys.each_with_index do |key, index|
-        @qualities[index] = data[:qualityNames][key] || key.to_s.capitalize
+        @qualities[index] = data[:qualities][key] || key.to_s.capitalize
       end
     end
 


### PR DESCRIPTION
Just hit this error on master in GameItemSchema

```
		"status": 1,
		"items_game_url": "http://media.steampowered.com/apps/440/scripts/items/items_game.9c3a78207db4c80958e51e32626e1518d397adb2.txt",
		"qualities": {
			"Normal": 0,
			"rarity1": 1,
			"rarity2": 2,
			"vintage": 3,
			"rarity3": 4,
			"rarity4": 5,
			"Unique": 6,
			"community": 7,
			...
		},
		"originNames": [
			...
```