### PR TITLE
Update GameInventory#fetch method

### DIFF
--- a/lib/steam-condenser/community/game_inventory.rb
+++ b/lib/steam-condenser/community/game_inventory.rb
@@ -142,7 +142,7 @@ module SteamCondenser::Community
           if item.preliminary?
             @preliminary_items << item
           else
-            @items[item.backpack_position - 1] = item
+            @items[item.backpack_position] = item
           end
         end
       end


### PR DESCRIPTION
If the value of an item's backpack_position is 0, then subtracting 1 from it would result in an IndexError.
Here's a sample error message:

```
/home/rafael/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/steam-condenser-1.3.11/lib/steam/community/game_inventory.rb:142:
in `block in fetch': index -1 too small for array; minimum: 0 (IndexError)
```