### PR TITLE
Fix deprecated usage of `Kernel#open` to open URIs

### DIFF
--- a/lib/steam-condenser/community/web_api.rb
+++ b/lib/steam-condenser/community/web_api.rb
@@ -132,7 +132,7 @@ module SteamCondenser::Community
           debug_url = @@api_key.nil? ? url : url.gsub(@@api_key, 'SECRET')
           log.debug "Querying Steam Web API: #{debug_url}"
         end
-        open(url, { 'Content-Type' => 'application/x-www-form-urlencoded' , proxy: true }).read
+        URI.open(url, { 'Content-Type' => 'application/x-www-form-urlencoded' , proxy: true }).read
       rescue OpenURI::HTTPError
         status = $!.io.status[0]
         status = [status, ''] unless status.is_a? Array

--- a/lib/steam-condenser/community/xml_data.rb
+++ b/lib/steam-condenser/community/xml_data.rb
@@ -20,7 +20,7 @@ module SteamCondenser::Community
     # @return [Hash<String, Object>] The data parsed from the XML document
     # @raise [Error] if an error occurs while parsing the XML data
     def parse(url)
-      data = open url, proxy: true
+      data = URI.open(url, proxy: true)
       @xml_data = MultiXml.parse(data).values.first
     rescue
       raise SteamCondenser::Error.new "XML data could not be parsed: #{$!.message}", $!

--- a/test/steam-condenser/community/test_steam_group.rb
+++ b/test/steam-condenser/community/test_steam_group.rb
@@ -31,7 +31,7 @@ class TestSteamGroup < Test::Unit::TestCase
 
     should 'be able to fetch its members and properties' do
       url = fixture_io 'valve-members.xml'
-      Community::SteamGroup.any_instance.expects(:open).with('http://steamcommunity.com/gid/103582791429521412/memberslistxml?p=1', proxy: true).returns url
+      URI.expects(:open).with('http://steamcommunity.com/gid/103582791429521412/memberslistxml?p=1', proxy: true).returns url
 
       group = Community::SteamGroup.new 103582791429521412
       members = group.members
@@ -69,7 +69,7 @@ class TestSteamGroup < Test::Unit::TestCase
     should 'raise an exception when parsing invalid XML' do
       error = assert_raises Error do
         url = fixture_io 'invalid.xml'
-        Community::SteamGroup.any_instance.expects(:open).with('http://steamcommunity.com/groups/valve/memberslistxml?p=1', proxy: true).returns url
+        URI.expects(:open).with('http://steamcommunity.com/groups/valve/memberslistxml?p=1', proxy: true).returns url
 
         Community::SteamGroup.new 'valve'
       end
@@ -78,7 +78,7 @@ class TestSteamGroup < Test::Unit::TestCase
 
     should 'be able to parse just the member count' do
       url = fixture_io 'valve-members.xml'
-      Community::SteamGroup.any_instance.expects(:open).with('http://steamcommunity.com/groups/valve/memberslistxml?p=1', proxy: true).returns url
+      URI.expects(:open).with('http://steamcommunity.com/groups/valve/memberslistxml?p=1', proxy: true).returns url
 
       group = Community::SteamGroup.new 'valve', false
       assert_equal 239, group.member_count

--- a/test/steam-condenser/community/test_steam_id.rb
+++ b/test/steam-condenser/community/test_steam_id.rb
@@ -87,7 +87,7 @@ class TestSteamId < Test::Unit::TestCase
 
     should 'be able to fetch its data' do
       url = fixture_io 'sonofthor.xml'
-      Community::SteamId.any_instance.expects(:open).with('http://steamcommunity.com/id/son_of_thor?xml=1', proxy: true).returns url
+      URI.expects(:open).with('http://steamcommunity.com/id/son_of_thor?xml=1', proxy: true).returns url
 
       steam_id = Community::SteamId.new 'Son_of_Thor'
 
@@ -157,7 +157,7 @@ class TestSteamId < Test::Unit::TestCase
     should 'raise an exception when parsing invalid XML' do
       error = assert_raises Error do
         url = fixture_io 'invalid.xml'
-        Community::SteamId.any_instance.expects(:open).with('http://steamcommunity.com/id/son_of_thor?xml=1', proxy: true).returns url
+        URI.expects(:open).with('http://steamcommunity.com/id/son_of_thor?xml=1', proxy: true).returns url
 
         Community::SteamId.new 'Son_of_Thor'
       end

--- a/test/steam-condenser/community/test_web_api.rb
+++ b/test/steam-condenser/community/test_web_api.rb
@@ -59,7 +59,7 @@ class TestWebApi < Test::Unit::TestCase
 
     should 'load data from the Steam Community Web API' do
       data = mock read: 'data'
-      Community::WebApi.expects(:open).with do |url, options|
+      URI.expects(:open).with do |url, options|
         options == { proxy: true, 'Content-Type' => 'application/x-www-form-urlencoded' } &&
         url.start_with?('https://api.steampowered.com/interface/method/v2/?') &&
         (url.split('?').last.split('&') & %w{test=param format=json key=0123456789ABCDEF0123456789ABCDEF}).size == 3
@@ -72,7 +72,7 @@ class TestWebApi < Test::Unit::TestCase
       Community::WebApi.api_key = nil
 
       data = mock read: 'data'
-      Community::WebApi.expects(:open).with do |url, options|
+      URI.expects(:open).with do |url, options|
         options == { proxy: true, 'Content-Type' => 'application/x-www-form-urlencoded' } &&
         url.start_with?('https://api.steampowered.com/interface/method/v2/?') &&
         (url.split('?').last.split('&') & %w{test=param format=json}).size == 2
@@ -84,7 +84,7 @@ class TestWebApi < Test::Unit::TestCase
     should 'handle unauthorized access error when loading data' do
       io = mock status: [401]
       http_error = OpenURI::HTTPError.new '', io
-      Community::WebApi.expects(:open).raises http_error
+      URI.expects(:open).raises http_error
 
       error = assert_raises Error::WebApi do
         Community::WebApi.get :json, 'interface', 'method', 2, test: 'param'
@@ -95,7 +95,7 @@ class TestWebApi < Test::Unit::TestCase
     should 'handle generic HTTP errors when loading data' do
       io = mock status: [[404, 'Not found']]
       http_error = OpenURI::HTTPError.new '', io
-      Community::WebApi.expects(:open).raises http_error
+      URI.expects(:open).raises http_error
 
       error = assert_raises Error::WebApi do
         Community::WebApi.get :json, 'interface', 'method', 2, test: 'param'
@@ -107,7 +107,7 @@ class TestWebApi < Test::Unit::TestCase
       Community::WebApi.secure = false
 
       data = mock read: 'data'
-      Community::WebApi.expects(:open).with do |url, options|
+      URI.expects(:open).with do |url, options|
         options == { proxy: true, 'Content-Type' => 'application/x-www-form-urlencoded' } &&
         url.start_with?('http://api.steampowered.com/interface/method/v2/?') &&
         (url.split('?').last.split('&') & %w{test=param format=json key=0123456789ABCDEF0123456789ABCDEF}).size == 3


### PR DESCRIPTION
Ruby 2.7 deprecated the usage of `Kernel#open` to open URIs directly,
leading to a deprecation warning and an argument error due to
`Kernel#open` not handling more than one argument.

You can reproduce the error as follows:
```
[4] pry(main)> require 'steam-condenser';
[5] pry(main)> ::WebApi.api_key = '*snip*';
[6] pry(main)> SteamId.resolve_vanity_url('morrolan-lz');
/home/michael/.gem/ruby/2.7.2/gems/steam-condenser-1.3.11/lib/steam/community/web_api.rb:130: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
ArgumentError: extra arguments
from /opt/rubies/ruby-2.7.2/lib/ruby/2.7.0/open-uri.rb:153:in `open_uri'
```